### PR TITLE
feat(signatures): update ScopedAtProto to explicit did parameter

### DIFF
--- a/packages/plugin-signatures/backend/__test__/mock-context.ts
+++ b/packages/plugin-signatures/backend/__test__/mock-context.ts
@@ -41,12 +41,12 @@ export function createMockAtProto(): MockAtProto {
     getRecord(did: string, collection: string, rkey: string): Promise<unknown> {
       return Promise.resolve(records.get(`${did}:${collection}:${rkey}`) ?? null)
     },
-    putRecord(collection: string, rkey: string, record: unknown): Promise<void> {
-      records.set(`:${collection}:${rkey}`, record)
+    putRecord(did: string, collection: string, rkey: string, record: unknown): Promise<void> {
+      records.set(`${did}:${collection}:${rkey}`, record)
       return Promise.resolve()
     },
-    deleteRecord(collection: string, rkey: string): Promise<void> {
-      records.delete(`:${collection}:${rkey}`)
+    deleteRecord(did: string, collection: string, rkey: string): Promise<void> {
+      records.delete(`${did}:${collection}:${rkey}`)
       return Promise.resolve()
     },
   }

--- a/packages/plugin-signatures/backend/__test__/routes.test.ts
+++ b/packages/plugin-signatures/backend/__test__/routes.test.ts
@@ -200,7 +200,7 @@ describe('signature routes', () => {
       expect(res.statusCode).toBe(200)
 
       // Verify PDS write
-      const pdsRecord = atproto.records.get(':forum.barazo.actor.signature:self') as
+      const pdsRecord = atproto.records.get('did:plc:user1:forum.barazo.actor.signature:self') as
         | { text: string }
         | undefined
       expect(pdsRecord).toBeDefined()

--- a/packages/plugin-signatures/backend/routes.ts
+++ b/packages/plugin-signatures/backend/routes.ts
@@ -139,7 +139,7 @@ export const signatureRoutes: FastifyPluginCallback<SignatureRoutesOpts> = (app,
     }
 
     // Write to user's PDS
-    await ctx.atproto.putRecord('forum.barazo.actor.signature', 'self', {
+    await ctx.atproto.putRecord(user.did, 'forum.barazo.actor.signature', 'self', {
       text: body.data.text,
       createdAt: new Date().toISOString(),
     })

--- a/packages/plugin-signatures/backend/types.ts
+++ b/packages/plugin-signatures/backend/types.ts
@@ -13,8 +13,8 @@ export interface ScopedDatabase {
 
 export interface ScopedAtProto {
   getRecord(did: string, collection: string, rkey: string): Promise<unknown>
-  putRecord(collection: string, rkey: string, record: unknown): Promise<void>
-  deleteRecord(collection: string, rkey: string): Promise<void>
+  putRecord(did: string, collection: string, rkey: string, record: unknown): Promise<void>
+  deleteRecord(did: string, collection: string, rkey: string): Promise<void>
 }
 
 export interface ScopedCache {


### PR DESCRIPTION
## Summary

- Update `ScopedAtProto` interface: `putRecord` and `deleteRecord` now take `did: string` as first parameter
- Update signatures plugin routes and tests to pass `user.did` explicitly

Coordinated with singi-labs/barazo-api#150 which changes the interface contract.

## Test plan

- [x] All 55 tests pass
- [ ] CI pipeline passes