### PR TITLE
fix(signatures): point plugin.json paths to compiled dist/ output

### DIFF
--- a/packages/plugin-signatures/plugin.json
+++ b/packages/plugin-signatures/plugin.json
@@ -54,17 +54,17 @@
     }
   },
   "hooks": {
-    "onInstall": "./backend/hooks.js#onInstall",
-    "onUninstall": "./backend/hooks.js#onUninstall",
-    "onEnable": "./backend/hooks.js#onEnable",
-    "onDisable": "./backend/hooks.js#onDisable",
-    "onProfileSync": "./backend/hooks.js#onProfileSync"
+    "onInstall": "./dist/backend/hooks.js#onInstall",
+    "onUninstall": "./dist/backend/hooks.js#onUninstall",
+    "onEnable": "./dist/backend/hooks.js#onEnable",
+    "onDisable": "./dist/backend/hooks.js#onDisable",
+    "onProfileSync": "./dist/backend/hooks.js#onProfileSync"
   },
   "backend": {
-    "routes": "./backend/routes.js",
+    "routes": "./dist/backend/routes.js",
     "migrations": "./backend/migrations/"
   },
   "frontend": {
-    "register": "./frontend/register.js"
+    "register": "./dist/frontend/register.js"
   }
 }


### PR DESCRIPTION
## Summary

- `plugin.json` hook refs pointed to `./backend/hooks.js` but TypeScript compiles to `dist/backend/hooks.js`
- Same issue for `backend.routes` and `frontend.register`
- In Docker, the raw source directory is copied to node_modules, so Node.js can't find `.js` files at the source paths
- Updated all paths to `./dist/backend/*.js` and `./dist/frontend/*.js`

This caused `ERR_MODULE_NOT_FOUND` crashes on staging deploy.

## Test plan

- [x] All 55 plugin tests pass
- [x] Build produces expected files in `dist/backend/`
- [ ] CI passes