### PR TITLE
feat(signatures): add backend-only build for Docker context

### DIFF
--- a/packages/plugin-signatures/package.json
+++ b/packages/plugin-signatures/package.json
@@ -16,6 +16,7 @@
   ],
   "scripts": {
     "build": "tsc",
+    "build:backend": "tsc -p tsconfig.backend.json",
     "test": "vitest run"
   },
   "peerDependencies": {

--- a/packages/plugin-signatures/tsconfig.backend.json
+++ b/packages/plugin-signatures/tsconfig.backend.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "jsx": "preserve"
+  },
+  "include": ["backend/**/*.ts"],
+  "exclude": ["frontend/**/*"]
+}


### PR DESCRIPTION
## Summary
- Add `tsconfig.backend.json` that excludes frontend TSX files
- Add `build:backend` script to package.json

## Context
The API Docker image only needs plugin backend code (hooks, routes, migrations). Frontend components are loaded by barazo-web. Building the full plugin in Docker fails because React types aren't available in the API build context (`moduleResolution: "NodeNext"` + no `@types/react`).

The companion PR in barazo-api will change the Dockerfile to use `build:backend`.

Fixes singi-labs/barazo-workspace#94