### PR TITLE
fix(plugin-signatures): add .js extensions to ESM imports

### DIFF
--- a/packages/plugin-signatures/frontend/register.ts
+++ b/packages/plugin-signatures/frontend/register.ts
@@ -1,7 +1,7 @@
 import type { ComponentType } from 'react'
-import { CommunitySignatureField } from './CommunitySignatureField'
-import { DefaultSignatureField } from './DefaultSignatureField'
-import { PostSignature } from './PostSignature'
+import { CommunitySignatureField } from './CommunitySignatureField.js'
+import { DefaultSignatureField } from './DefaultSignatureField.js'
+import { PostSignature } from './PostSignature.js'
 
 interface PluginComponentRegistry {
   add: (slot: string, component: ComponentType<Record<string, unknown>>) => void


### PR DESCRIPTION
## Summary

- Add `.js` extensions to relative imports in `frontend/register.ts`
- The bare imports (`'./CommunitySignatureField'`) broke Turbopack's strict ESM resolution in barazo-web CI builds
- Node.js ESM (`"type": "module"` + `"moduleResolution": "NodeNext"`) requires `.js` extensions for relative imports even when source files are `.ts`/`.tsx`

## Test plan

- [ ] `pnpm test` passes in barazo-plugins
- [ ] barazo-web CI build passes after this is merged (CI shallow-clones this repo)