### PR TITLE
fix(plugin-signatures): revert .js extensions in frontend imports

### DIFF
--- a/packages/plugin-signatures/frontend/register.ts
+++ b/packages/plugin-signatures/frontend/register.ts
@@ -1,7 +1,7 @@
 import type { ComponentType } from 'react'
-import { CommunitySignatureField } from './CommunitySignatureField.js'
-import { DefaultSignatureField } from './DefaultSignatureField.js'
-import { PostSignature } from './PostSignature.js'
+import { CommunitySignatureField } from './CommunitySignatureField'
+import { DefaultSignatureField } from './DefaultSignatureField'
+import { PostSignature } from './PostSignature'
 
 interface PluginComponentRegistry {
   add: (slot: string, component: ComponentType<Record<string, unknown>>) => void


### PR DESCRIPTION
## Summary

Reverts the `.js` import extensions added in #7 and #8. Turbopack with `transpilePackages` resolves bare imports to `.tsx` files correctly, but **cannot** map `.js` → `.tsx`. The `.js` extensions broke the barazo-web CI build.

Last working state used bare imports (commit `3eacbad`).

## Test plan

- [ ] barazo-web CI build passes after this is merged