### PR TITLE
docs: update TODO comment for @singi-labs/barazo-lexicons

### DIFF
--- a/packages/plugin-signatures/backend/validation.ts
+++ b/packages/plugin-signatures/backend/validation.ts
@@ -2,7 +2,7 @@ import { z } from 'zod'
 
 /**
  * Mirrors the forum.barazo.actor.signature lexicon constraints.
- * Once @singi-labs/lexicons is published to npm, import from there instead.
+ * Once @singi-labs/barazo-lexicons is published to npm, import from there instead.
  */
 export const signatureTextSchema = z.string().min(1).max(3000)
 


### PR DESCRIPTION
## Summary
- Updates TODO comment in plugin-signatures to reference `@singi-labs/barazo-lexicons`
- Part of cross-repo rename (see singi-labs/barazo-lexicons#56)

## Test plan
- [x] Comment-only change, no functional impact