### PR TITLE
fix(plugin-signatures): drop .js extensions from frontend imports

### DIFF
--- a/packages/plugin-signatures/frontend/__test__/CommunitySignatureField.test.tsx
+++ b/packages/plugin-signatures/frontend/__test__/CommunitySignatureField.test.tsx
@@ -3,7 +3,7 @@ import '@testing-library/jest-dom/vitest'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, waitFor, cleanup } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
-import { CommunitySignatureField } from '../CommunitySignatureField.js'
+import { CommunitySignatureField } from '../CommunitySignatureField'
 
 const mockFetch = vi.fn()
 globalThis.fetch = mockFetch

--- a/packages/plugin-signatures/frontend/__test__/DefaultSignatureField.test.tsx
+++ b/packages/plugin-signatures/frontend/__test__/DefaultSignatureField.test.tsx
@@ -3,7 +3,7 @@ import '@testing-library/jest-dom/vitest'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, waitFor, cleanup } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
-import { DefaultSignatureField } from '../DefaultSignatureField.js'
+import { DefaultSignatureField } from '../DefaultSignatureField'
 
 const mockFetch = vi.fn()
 globalThis.fetch = mockFetch

--- a/packages/plugin-signatures/frontend/__test__/PostSignature.test.tsx
+++ b/packages/plugin-signatures/frontend/__test__/PostSignature.test.tsx
@@ -2,7 +2,7 @@
 import '@testing-library/jest-dom/vitest'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, waitFor, cleanup } from '@testing-library/react'
-import { PostSignature } from '../PostSignature.js'
+import { PostSignature } from '../PostSignature'
 
 const mockFetch = vi.fn()
 globalThis.fetch = mockFetch

--- a/packages/plugin-signatures/frontend/__test__/register.test.ts
+++ b/packages/plugin-signatures/frontend/__test__/register.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { register } from '../register.js'
+import { register } from '../register'
 
 describe('register', () => {
   it('registers all three components to correct slots', () => {

--- a/packages/plugin-signatures/frontend/register.ts
+++ b/packages/plugin-signatures/frontend/register.ts
@@ -1,7 +1,7 @@
 import type { ComponentType } from 'react'
-import { CommunitySignatureField } from './CommunitySignatureField.js'
-import { DefaultSignatureField } from './DefaultSignatureField.js'
-import { PostSignature } from './PostSignature.js'
+import { CommunitySignatureField } from './CommunitySignatureField'
+import { DefaultSignatureField } from './DefaultSignatureField'
+import { PostSignature } from './PostSignature'
 
 interface PluginComponentRegistry {
   add: (slot: string, component: ComponentType<Record<string, unknown>>) => void


### PR DESCRIPTION
## Summary

- Remove `.js` extensions from relative imports in plugin-signatures frontend files
- Frontend source is consumed directly by Next.js via `transpilePackages`, not compiled to JS
- The `.js` imports break Turbopack when the plugin is copied into `node_modules` during CI (Turbopack doesn't resolve `.js` → `.tsx` inside `node_modules`)
- Extensionless imports work with `moduleResolution: "bundler"` (already configured in `tsconfig.frontend.json`)

Companion to singi-labs/barazo-web#216 which fixes the CI setup action.

## Test plan

- [x] All 55 plugin tests pass locally