### PR TITLE
fix: split backend/frontend typecheck with project references

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -21,5 +21,5 @@ export default tseslint.config(
       '@typescript-eslint/consistent-type-imports': ['error', { prefer: 'type-imports' }],
     },
   },
-  { ignores: ['**/dist/', 'node_modules/', '*.config.*'] }
+  { ignores: ['**/dist/', 'node_modules/', '**/*.config.*'] }
 )

--- a/packages/plugin-signatures/tsconfig.backend.json
+++ b/packages/plugin-signatures/tsconfig.backend.json
@@ -1,8 +1,10 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "composite": true,
+    "outDir": "dist",
+    "rootDir": ".",
     "jsx": "preserve"
   },
-  "include": ["backend/**/*.ts"],
-  "exclude": ["frontend/**/*"]
+  "include": ["backend/**/*.ts"]
 }

--- a/packages/plugin-signatures/tsconfig.frontend.json
+++ b/packages/plugin-signatures/tsconfig.frontend.json
@@ -1,11 +1,12 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "composite": true,
     "outDir": "dist",
     "rootDir": ".",
     "jsx": "react-jsx",
     "module": "ESNext",
-    "moduleResolution": "bundler"
+    "moduleResolution": "Bundler"
   },
   "include": ["frontend/**/*.ts", "frontend/**/*.tsx"]
 }

--- a/packages/plugin-signatures/tsconfig.json
+++ b/packages/plugin-signatures/tsconfig.json
@@ -1,9 +1,4 @@
 {
-  "extends": "../../tsconfig.base.json",
-  "compilerOptions": {
-    "outDir": "dist",
-    "rootDir": ".",
-    "jsx": "react-jsx"
-  },
-  "include": ["backend/**/*.ts", "frontend/**/*.ts", "frontend/**/*.tsx", "vitest.config.ts"]
+  "files": [],
+  "references": [{ "path": "./tsconfig.backend.json" }, { "path": "./tsconfig.frontend.json" }]
 }


### PR DESCRIPTION
## Summary

- Converts `packages/plugin-signatures/tsconfig.json` from a flat config into a project-references root that delegates to `tsconfig.backend.json` (NodeNext) and `tsconfig.frontend.json` (Bundler)
- Adds `composite: true` to both sub-configs so `tsc -b` works with project references
- Fixes ESLint ignore glob (`*.config.*` -> `**/*.config.*`) to match nested config files

## Root cause

`tsc -b` used a single tsconfig that applied `moduleResolution: "NodeNext"` to both backend and frontend code. NodeNext requires `.js` extensions on relative imports, but frontend code is consumed by Next.js's bundler which doesn't need them. This caused TS2835 errors that kept getting "fixed" by flipping import extensions back and forth (PRs #9, #11).

The separate `tsconfig.frontend.json` with `moduleResolution: "Bundler"` already existed but wasn't wired into the typecheck path.

## Test plan

- [x] `pnpm typecheck` passes locally
- [x] `pnpm lint` passes locally
- [x] `pnpm build` passes locally
- [x] `pnpm test` passes (110 tests)
- [x] `pnpm format:check` passes
- [ ] CI passes on this PR